### PR TITLE
Relax the version requirement of eventmachine

### DIFF
--- a/twitter-stream.gemspec
+++ b/twitter-stream.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.markdown", "LICENSE"]
 
-  s.add_runtime_dependency('eventmachine', "~> 1.0.7")
+  s.add_runtime_dependency('eventmachine', ">= 1.0.7")
   s.add_runtime_dependency('simple_oauth', '~> 0.3.0')
   s.add_runtime_dependency('http_parser.rb', '~> 0.6.0')
   s.add_development_dependency('rspec', "~> 2.5.0")


### PR DESCRIPTION
Eventmachine 1.0.7 has build problems on some platforms and with newer C++ compilers that have been fixed in the 1.2.x series.