### PR TITLE
Try fix from @thbar

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -202,7 +202,9 @@ module Twitter
       @state   = :init
       @buffer  = BufferedTokenizer.new("\r")
       @stream  = ''
+    end
 
+    def reset_parser
       @parser  = Http::Parser.new
       @parser.on_headers_complete = method(:handle_headers_complete)
       @parser.on_body = method(:receive_stream_data)
@@ -235,6 +237,8 @@ module Twitter
     end
 
     def send_request
+      reset_parser
+
       data = []
       request_uri = @options[:path]
 


### PR DESCRIPTION
I've seen some errors like:

```
Agents::TwitterStreamAgent-9-544c39979c8c9da8c4db87ba1b4ae75769f92946 Exception Could not parse data entirely (0 != 531):
/app/vendor/bundle/ruby/2.5.0/bundler/gems/twitter-stream-a80822d57950/lib/twitter/json_stream.rb:128:in `<<'
/app/vendor/bundle/ruby/2.5.0/bundler/gems/twitter-stream-a80822d57950/lib/twitter/json_stream.rb:128:in `receive_data'
/app/vendor/bundle/ruby/2.5.0/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run_machine'
/app/vendor/bundle/ruby/2.5.0/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run'
/app/app/models/agents/twitter_stream_agent.rb:164:in `run'
/app/app/concerns/long_runnable.rb:71:in `block in run!'
```

I'm trying this fix, based on https://github.com/mremond/twitter-stream/commit/72296d6ba90fbdeb57dddec66129495003c2ebe6, on my local Huginn instance to see if it helps.

FYI @dsander 